### PR TITLE
sign

### DIFF
--- a/gateway/src/main/java/travel/auth/AuthorizationFilter.java
+++ b/gateway/src/main/java/travel/auth/AuthorizationFilter.java
@@ -1,0 +1,99 @@
+package travel.auth;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.Claim;
+
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class AuthorizationFilter extends AbstractGatewayFilterFactory<AuthorizationFilter.Config> {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    public AuthorizationFilter() {
+        super(Config.class);
+    }
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            String authorizationHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
+    
+            if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+                exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+                return exchange.getResponse().setComplete();
+            }
+    
+            String token = authorizationHeader.substring(7);
+    
+            if (isTokenExpired(token)) {
+                String payload = token.split("\\.")[1];
+                String json = new String(Base64.getDecoder().decode(payload));
+                String username = new JSONObject(json).getString("username");
+                String refreshToken = getRefreshToken(username);
+                String newToken = requestNewToken(refreshToken);
+    
+                exchange.getResponse().getHeaders().add("newauthorization", "Bearer " + newToken);
+            }
+    
+            return chain.filter(exchange);
+        };
+    }
+    
+    private boolean isTokenExpired(String token) {
+        try {
+            token = token.substring(7);
+
+            JWT.require(Algorithm.HMAC512(jwtSecret.getBytes()))
+                    .build()
+                    .verify(token)//검증 
+                    .getClaims();//검증된 토큰의 claims를 가져옴
+
+            return false;
+        } catch (TokenExpiredException e) {
+            return true;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    //리프레쉬 토큰 알아내기 위한 것
+    private String getRefreshToken(String username) {
+        WebClient webClient = WebClient.create("http://localhost:8088");//요청 주소
+        String refreshToken = webClient.get()
+                .uri("/users/{username}/refreshToken", username) //상세 주소, 
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    
+        return refreshToken;
+    }
+    
+    //새로운 엑세스 토큰 발급을 위한 것
+    private String requestNewToken(String refreshToken) {
+        WebClient webClient = WebClient.create("http://localhost:8088");
+        String newToken = webClient.post()
+                .uri("/users/token/refresh")
+                .body(BodyInserters.fromValue(refreshToken))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    
+        return newToken;
+    }
+    
+    public static class Config {
+    }
+}

--- a/gateway/src/main/java/travel/auth/CorsConfiguration.java
+++ b/gateway/src/main/java/travel/auth/CorsConfiguration.java
@@ -1,0 +1,21 @@
+package travel.auth;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.CorsRegistry;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+@Configuration
+public class CorsConfiguration implements WebFluxConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .exposedHeaders("newauthorization")  // 이 부분 추가
+                .allowCredentials(true);
+                
+
+    }
+}

--- a/gateway/src/main/java/travel/auth/JwtProperties.java
+++ b/gateway/src/main/java/travel/auth/JwtProperties.java
@@ -1,0 +1,11 @@
+package travel.auth;
+
+public interface JwtProperties {
+    String TOKEN_PREFIX = "Bearer ";//접두, 공백을 만들면 헤더에 저장할 수 있고 공백이 없으면 쿠키 
+    String HEADER_STRING = "Authorization";
+    int AJ_TIME=10;// jwt
+    int RT_TIME=10080; //refresh
+    String TOKENNAME = "COS토큰";
+    String SECRET = "mcos"; //비밀값
+
+}

--- a/gateway/src/main/java/travel/auth/SecurityConfig.java
+++ b/gateway/src/main/java/travel/auth/SecurityConfig.java
@@ -1,0 +1,23 @@
+package travel.auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http
+            
+            .authorizeExchange(exchange -> exchange
+            .anyExchange().permitAll())
+
+            .csrf().disable();
+            
+        return http.build();
+    }
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+jwt:
+  secret: travel
+  
 server:
   port: 8088
 
@@ -7,6 +10,9 @@ spring:
   profiles: default
   cloud:
     gateway:
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
+
 #<<< API Gateway / Routes
       routes:
         - id: payment
@@ -52,6 +58,9 @@ spring:
   profiles: docker
   cloud:
     gateway:
+      default-filters:
+        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
+
       routes:
         - id: payment
           uri: http://payment:8080

--- a/user/src/main/java/travel/auth/JwtAuthenticationFilter.java
+++ b/user/src/main/java/travel/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,125 @@
+package travel.auth;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import travel.domain.User;
+import travel.domain.UserRepository;
+
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+
+    private String jwtSecret;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    private final UserRepository userRepository;
+
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager, UserRepository userRepository, String jwtSecret) {// 생성자
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.jwtSecret = jwtSecret;
+        // 로그인 주소를 변경합니다.
+        this.setFilterProcessesUrl("/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        System.out.println("JwtAuthenticationFilter :로그인 시도중");
+        try {
+            ObjectMapper om = new ObjectMapper();// 객체 매핑
+            User user = om.readValue(request.getInputStream(), User.class);
+            System.out.println(user);
+
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                    user.getUsername(), user.getPassword());
+
+            Authentication authentication = authenticationManager.authenticate(authenticationToken);
+
+            PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+            System.out.println(principalDetails.getUser().getUsername());
+
+            return authentication;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+            Authentication authResult) throws IOException, ServletException {
+        System.out.println("인증이 무사히 성공됨");
+
+        PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
+
+        // access 토큰 발급
+        String accessToken = createAccessToken(principalDetails);
+
+        // refresh 토큰 발급
+        String refreshToken = createRefreshToken(principalDetails);
+
+        // 리프레시 토큰으로 사용자 업데이트
+        Optional<User> optionalUser = userRepository.findByUsername(principalDetails.getUser().getUsername());
+        optionalUser.ifPresent(user -> {
+            user.setRefreshToken(refreshToken);
+            userRepository.save(user);
+        });
+
+        // 헤더에 토큰 추가
+        response.addHeader(JwtProperties.HEADER_STRING, JwtProperties.TOKEN_PREFIX + accessToken);
+        response.setHeader("Access-Control-Expose-Headers", JwtProperties.HEADER_STRING);
+    }
+
+    // access 토큰 생성 메소드
+    public String createAccessToken(PrincipalDetails principalDetails) {
+        String accessToken = JWT.create()
+                .withSubject(JwtProperties.TOKENNAME)
+                .withExpiresAt(Date.from(Instant.now().plus(JwtProperties.AJ_TIME, ChronoUnit.MINUTES)))
+                .withClaim("id", principalDetails.getUser().getId())
+                .withClaim("username", principalDetails.getUser().getUsername())
+                .withClaim("roles", principalDetails.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .map(String::trim)
+                        .collect(Collectors.toList()))
+                .sign(Algorithm.HMAC512(jwtSecret));
+
+        return accessToken;
+    }
+
+    public String createRefreshToken(PrincipalDetails principalDetails) {
+        // refresh 토큰 발급
+        String refreshToken = JWT.create()
+                .withSubject(JwtProperties.TOKENNAME)
+                .withExpiresAt(Date.from(Instant.now().plus(JwtProperties.RT_TIME, ChronoUnit.MINUTES)))
+                .withClaim("id", principalDetails.getUser().getId())
+                .withClaim("username", principalDetails.getUser().getUsername())
+                .sign(Algorithm.HMAC512(jwtSecret));
+        return refreshToken;
+    }
+}

--- a/user/src/main/java/travel/auth/JwtProperties.java
+++ b/user/src/main/java/travel/auth/JwtProperties.java
@@ -1,0 +1,12 @@
+package travel.auth;
+
+public interface JwtProperties {
+    String TOKEN_PREFIX = "Bearer ";//접두, 공백을 만들면 헤더에 저장할 수 있고 공백이 없으면 쿠키 
+    String HEADER_STRING = "Authorization";
+    int AJ_TIME=10;// jwt
+    int RT_TIME=10080;
+    String TOKENNAME = "COS토큰";
+    String SECRET = "mcos"; //비밀값
+
+
+}

--- a/user/src/main/java/travel/auth/PrincipalDetails.java
+++ b/user/src/main/java/travel/auth/PrincipalDetails.java
@@ -1,0 +1,64 @@
+package travel.auth;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import travel.domain.User;
+import lombok.Data;
+
+@Data
+public class PrincipalDetails implements UserDetails{
+    
+    @Autowired
+    private User user;
+
+    public PrincipalDetails(User user){
+        this.user=user;
+    }
+
+ @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        user.getRoleList().forEach(r->{
+            authorities.add(()->r);
+        });
+        return authorities;
+
+    }
+
+ 
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+    
+}

--- a/user/src/main/java/travel/auth/PrincipalDetailsService.java
+++ b/user/src/main/java/travel/auth/PrincipalDetailsService.java
@@ -1,0 +1,35 @@
+package travel.auth;
+
+import java.util.Optional;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import travel.domain.User;
+import travel.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> optionalUser = userRepository.findByUsername(username);
+        
+    
+        if(optionalUser.isPresent()){
+            User user = optionalUser.get();
+            return new PrincipalDetails(user);
+        } else {
+            System.out.println("로그인 실패");
+        }
+        return null;
+
+    }
+    
+}

--- a/user/src/main/java/travel/auth/SecurityConfig.java
+++ b/user/src/main/java/travel/auth/SecurityConfig.java
@@ -1,0 +1,84 @@
+package travel.auth;
+
+import travel.domain.UserRepository;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter{
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+   
+    private final UserRepository userRepository;
+
+    //BCrypt 암호화를 사용하기 위한 메소드
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception{
+        
+        //csrf는 disable
+        http.csrf().disable();
+    
+        //세션을 사용x
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            // CrossOrigin(인증x), 시큐리티에 필터 등록(o)
+            //.addFilter(corsFilter)
+            // formLogin 방식 비활성화
+            .formLogin().disable()
+            .logout()
+            .logoutUrl("/logout") // 로그아웃 URL 설정
+            .invalidateHttpSession(true) // 세션 무효화
+            .and()
+            // httpBasic 방식 비활성화
+            .httpBasic().disable()
+            .addFilter(new JwtAuthenticationFilter(authenticationManager(), userRepository, jwtSecret))//생성자 
+            .exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint())
+                .accessDeniedHandler(accessDeniedHandler())
+            .and()
+            .authorizeRequests()
+            .anyRequest().permitAll();
+            }
+
+
+     // 인증 실패 핸들러 설정
+    private AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "사용할 권한이 없습니다.");
+        };
+    }
+
+    // 권한 없음 핸들러 설정
+    private AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.getWriter().write("권한이 없다.");
+        };
+    }
+    
+}

--- a/user/src/main/java/travel/domain/UserRepository.java
+++ b/user/src/main/java/travel/domain/UserRepository.java
@@ -1,5 +1,7 @@
 package travel.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import travel.domain.*;
@@ -7,4 +9,8 @@ import travel.domain.*;
 //<<< PoEAA / Repository
 @RepositoryRestResource(collectionResourceRel = "users", path = "users")
 public interface UserRepository
-    extends PagingAndSortingRepository<User, Long> {}
+    extends PagingAndSortingRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByRefreshToken(String refreshToken);}

--- a/user/src/main/java/travel/infra/UserController.java
+++ b/user/src/main/java/travel/infra/UserController.java
@@ -1,23 +1,57 @@
-package travel.infra;
+    package travel.infra;
 
-import java.util.Optional;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.transaction.Transactional;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+    import java.util.Optional;
+    import javax.servlet.http.HttpServletRequest;
+    import javax.servlet.http.HttpServletResponse;
+    import javax.transaction.Transactional;
+
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.*;
+    import org.springframework.web.bind.annotation.RequestMapping;
+    import org.springframework.web.bind.annotation.RestController;
+
+import travel.auth.JwtAuthenticationFilter;
+import travel.auth.PrincipalDetails;
 import travel.domain.*;
+    import org.springframework.web.bind.annotation.PostMapping;
+    import org.springframework.web.bind.annotation.RequestBody;
 
-//<<< Clean Arch / Inbound Adaptor
 
-@RestController
-// @RequestMapping(value="/users")
-@Transactional
-public class UserController {
+    //<<< Clean Arch / Inbound Adaptor
 
-    @Autowired
-    UserRepository userRepository;
-}
-//>>> Clean Arch / Inbound Adaptor
+    @RestController
+    //@RequestMapping(value="/users")
+    @Transactional()
+    public class UserController {
+
+        @Autowired
+        private UserRepository userRepository;
+
+
+        @PostMapping("/users/register")
+        public ResponseEntity<User> createUser(@RequestBody SignedUp signedUp) {
+            User user = new User();
+            user.register(signedUp);
+            userRepository.save(user);
+            return ResponseEntity.ok(user);
+        }
+        
+        @PostMapping("/users/token/refresh")
+        public ResponseEntity<String> createToken(@RequestBody String refreshToken){
+            Optional<User> optionalUser = userRepository.findByRefreshToken(refreshToken);
+            if(optionalUser.isPresent()){
+                User user = optionalUser.get();
+                //사용자 인증 정보 클래스 객체 생성
+                PrincipalDetails principalDetails = new PrincipalDetails(user);
+                                //accessToken 발급
+                JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(null, null, null);
+                String newAccessToken = jwtAuthenticationFilter.createAccessToken(principalDetails);
+                return ResponseEntity.ok(newAccessToken);
+            } else{
+                return ResponseEntity.ok("refresh Token 불일치");
+            }
+            
+        }
+    }
+    //>>> Clean Arch / Inbound Adaptor

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+jwt:
+  secret: travel
+
 server:
   port: 8080
 


### PR DESCRIPTION
시큐리티와 jwt를 사용한 회원가입과 로그인 구현

로그인을 하면 헤더에 accessToken이 생성되며, refresh 토큰은 사용자 db에 생성

게이트웨이에서 시큐리티와 각종 기능을 사용하기 위해 pom의 라이브러리 전체 수정(필요할 때 코드 드리겠습니다.)

게이트웨이에서 각 도메인으로 요청을 보내기 전 검증을 위한 검증 클래스 및 각종 클래스 추가

gatewayyml 파일에 검증을 위한 시크릿 키 값 추가, cors 중복 요청을 제거하기 위한 코드 추가

user.yml 토큰을 만들기 위한 시크릿 키 값 추가


